### PR TITLE
Update URLs to PGDP documentation

### DIFF
--- a/wsgi/templates/kppv_templates/kppvh-html.tmpl
+++ b/wsgi/templates/kppv_templates/kppvh-html.tmpl
@@ -230,7 +230,7 @@
 	  <span class='warning'>
 		The {{ "<title>" | e }} format is different than what PGDP or Project Gutenberg suggest.
 	  </span><br />
-      See <a href='http://www.pgdp.org/~jana/best-practices/pages/intro/html-css/#title-element'>PGPG's HTML Best Practices</a>
+      See <a href="https://www.pgdp.net/wiki/DP_Official_Documentation:PP_and_PPV/DP_HTML_Best_Practices/Introductory_Topics/HTML_and_CSS_for_PPers#The_.3Ctitle.3E_element">PGPG's HTML Best Practices</a>
 	</p>
   {% endif %}
 
@@ -351,7 +351,7 @@
   {% if not img.coverpage %}
     <p>
 	  No cover image found.<br />
-      See <a href='http://www.pgdp.org/~jana/best-practices/pages/case-studies/images/#displayed-cover-image'>PGPG's HTML Best Practices</a>
+      See <a href="https://www.pgdp.net/wiki/DP_Official_Documentation:PP_and_PPV/DP_HTML_Best_Practices/Case_Studies/Images#Cover_image:_displayed_in_the_HTML_and_.E2.80.9Cmobile.E2.80.9D_versions">PGPG's HTML Best Practices</a>
 	</p>
   {% else %}
     <p>
@@ -362,7 +362,7 @@
     {% if img.coverpage_invalid_ext %}
 	  <p>
 		Invalid file extension. Must be ".jpg". Is the image a jpeg file?<br />
-        See <a href='http://www.pgdp.org/~jana/best-practices/pages/case-studies/images/#displayed-cover-image'>PGPG's HTML Best Practices</a>
+        See <a href="https://www.pgdp.net/wiki/DP_Official_Documentation:PP_and_PPV/DP_HTML_Best_Practices/Case_Studies/Images#Cover_image:_displayed_in_the_HTML_and_.E2.80.9Cmobile.E2.80.9D_versions">PGPG's HTML Best Practices</a>
 	  </p>
 	{% endif %}
 


### PR DESCRIPTION
Some documentation is now 404. Updating to current URLs (at least, what I believe are correct links... please double-check and see if you agree these are the right links...)

See this forum thread:
<https://www.pgdp.net/phpBB3/viewtopic.php?f=3&t=64204&sid=3f07f9c94ecd476c8aa30c70fa8be828&start=15#p1231600>