### PR TITLE
Major update, mainly for HTML5

### DIFF
--- a/wsgi/comp_pp.py
+++ b/wsgi/comp_pp.py
@@ -1,771 +1,906 @@
-#!/usr/bin/env python3
+"""
+ppcomp.py - compare text from 2 files, ignoring html and formatting differences, for use by users
+of Distributed Proofreaders (https://www.pgdp.net)
 
-# -*- coding: utf-8 -*-
+Applies various transformations according to program options before passing the files to the Linux
+program dwdiff.
 
-# comp_pp - compare 2 files
+Copyright (C) 2012-2013, 2021 bibimbop at pgdp
 
-# Copyright (C) 2012-2013, 2021 bibimbop at pgdp
+Modified March 2022 by Robert Tonsing, per GPL section 5
 
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+Originally written as the standalone program comp_pp.py by bibimbop at PGDP as part of his PPTOOLS
+program. It is used as part of the PP Workbench with permission.
 
-import re
-import os
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+
 import argparse
-import tempfile
+import os
+import re
 import subprocess
-from lxml import etree
-import tinycss
+import tempfile
+import warnings
+
 import cssselect
-#from functools import partial
+import tinycss
+from lxml import etree
+from lxml.html import html5parser
 
-from helpers.exfootnotes import extract_footnotes_pp
-from helpers import sourcefile
-
+PG_EBOOK_START = '*** START OF'
+PG_EBOOK_END = '*** END OF'
 DEFAULT_TRANSFORM_CSS = '''
-                i:before, cite:before, em:before, abbr:before, dfn:before,
-                i:after, cite:after, em:after, abbr:after, dfn:after      { content: "_"; }
+  /* Italics */
+  i::before, cite::before, em::before,
+  i::after, cite::after, em::after { content: "_"; }
 
-                /* line breaks with <br /> will be ignored by
-                 *  normalize-space(). Add a space in all of them to work
-                 *  around. */
-                br:before { content: " "; }
+  /* Add spaces around td tags */
+  td::before, td::after { content: " "; }
+  
+  /* Remove thought breaks */
+  .tb { display: none; }
 
-                /* Add spaces around td tags. */
-                td:after, td:after { content: " "; }
+  /* Add space before br tags */
+  br::before { content: " "; }
 
-                /* Remove page numbers. It seems every PP has a different way. */
-                span[class^="pagenum"] { display: none }
-                p[class^="pagenum"] { display: none }
-                p[class^="page"] { display: none }
-                span[class^="pgnum"] { display: none }
-                div[id^="Page_"] { display: none }
-                div[class^="pagenum"] { display: none }
-            '''
+  /* Remove page numbers. It seems every PP has a different way. */
+  span[class^="pagenum"],
+  p[class^="pagenum"],
+  div[class^="pagenum"],
+  span[class^="pageno"],
+  p[class^="pageno"],
+  div[class^="pageno"],
+  p[class^="page"],
+  span[class^="pgnum"],
+  div[id^="Page_"] { display: none }
 
-def clear_element(element):
-    """In an XHTML tree, remove all sub-elements of a given element.
+  /* Superscripts, subscripts */
+  sup { text-transform:superscript; }
+  sub { text-transform:subscript; }
+'''
+# CSS used to display the diffs
+DIFF_CSS = '''
+body {
+  margin-left: 5%;
+  margin-right: 5%;
+}
+ins, del {
+  text-decoration: none;
+  border: 1px solid black;
+  background-color: whitesmoke;
+  font-size: larger;
+}
+ins, .second { color: green; }
+del, .first { color: purple; }
+.lineno { margin-right: 1em; }
+.bbox {
+  margin-left: auto;
+  margin-right: auto;
+  border: 1px dashed;
+  padding: 0 1em;
+  background-color: lightcyan;
+  width: 90%;
+  max-width: 50em;
+}
+h1, .center { text-align: center; }
+/* Use a CSS counter to number each diff. */
+body { counter-reset: diff; } /* set diff counter to 0 */
+hr::before {
+  counter-increment: diff; /* inc the diff counter ... */
+  content: "Diff " counter(diff) ": "; /* ... and display it */
+}
+.error-border {
+  border-style: double;
+  border-color: red;
+  border-width: 15px;
+}
+'''
+"""Note that 'º' and 'ª' are ordinals, assume they would be entered as-is, not superscript"""
+SUPERSCRIPTS = {
+    '0': '⁰', '1': '¹', '2': '²', '3': '³', '4': '⁴',
+    '5': '⁵', '6': '⁶', '7': '⁷', '8': '⁸', '9': '⁹',
+    'a': 'ᵃ', 'b': 'ᵇ', 'c': 'ᶜ', 'd': 'ᵈ', 'e': 'ᵉ',
+    'f': 'ᶠ', 'g': 'ᵍ', 'h': 'ʰ', 'i': 'ⁱ', 'j': 'ʲ',
+    'k': 'ᵏ', 'l': 'ˡ', 'm': 'ᵐ', 'n': 'ⁿ', 'o': 'ᵒ',
+    'p': 'ᵖ', 'r': 'ʳ', 's': 'ˢ', 't': 'ᵗ', 'u': 'ᵘ',
+    'v': 'ᵛ', 'w': 'ʷ', 'x': 'ˣ', 'y': 'ʸ', 'z': 'ᶻ',
+    'A': 'ᴬ', 'B': 'ᴮ', 'D': 'ᴰ', 'E': 'ᴱ', 'G': 'ᴳ',
+    'H': 'ᴴ', 'I': 'ᴵ', 'J': 'ᴶ', 'K': 'ᴷ', 'L': 'ᴸ',
+    'M': 'ᴹ', 'N': 'ᴺ', 'O': 'ᴼ', 'P': 'ᴾ', 'R': 'ᴿ',
+    'T': 'ᵀ', 'U': 'ᵁ', 'V': 'ⱽ', 'W': 'ᵂ', 'Æ': 'ᴭ', 'œ': 'ꟹ'
+}
+SUBSCRIPTS = {
+    '0': '₀', '1': '₁', '2': '₂', '3': '₃', '4': '₄',
+    '5': '₅', '6': '₆', '7': '₇', '8': '₈', '9': '₉',
+    'a': 'ₐ', 'e': 'ₑ', 'h': 'ₕ', 'i': 'ᵢ', 'j': 'ⱼ',
+    'k': 'ₖ', 'l': 'ₗ', 'm': 'ₘ', 'n': 'ₙ', 'o': 'ₒ',
+    'p': 'ₚ', 'r': 'ᵣ', 's': 'ₛ', 't': 'ₜ', 'u': 'ᵤ',
+    'v': 'ᵥ', 'x': 'ₓ'
+}
 
-    We can't properly remove an XML element while traversing the
-    tree. But we can clean it. Remove its text and children. However
-    the tail must be preserved because it belongs to the next element,
-    so re-attach."""
-    tail = element.tail
-    element.clear()
-    element.tail = tail
+
+def to_superscript(text):
+    """Convert to unicode superscripts"""
+    result = ''
+    for char in text:
+        try:
+            result += SUPERSCRIPTS[char]
+        except KeyError:
+            return text  # can't convert, just leave it
+    return result
 
 
-class pgdp_file(object):
-    """Stores and process a DP/text/html file.
-    """
+def to_subscript(text):
+    """Convert to unicode subscripts"""
+    result = ''
+    for char in text:
+        try:
+            result += SUBSCRIPTS[char]
+        except KeyError:
+            return text  # can't convert, just leave it
+    return result
+
+
+class PgdpFile:
+    """Base class: Store and process a DP text or html file"""
 
     def __init__(self, args):
-        self.text = None
-        self.words = None
-        self.myfile = sourcefile.SourceFile()
         self.args = args
-
-        # œ ligature - has_oe_ligature and has_oe_dp are mutually
-        # exclusive
-        self.has_oe_ligature = False # the real thing
-        self.has_oe_dp = False       # DP type: [oe]
-
-        # Conversion to latin1 ?
-        self.convert_to_latin1 = False
-
-        self.transform_func = []
-
-        # Footnotes, if extracted
-        self.footnotes = ""
-
-        # First line of the text. This is where <body> is for html.
-        self.start_line = 0
-
+        self.basename = ''
+        self.text = ''  # file text
+        self.start_line = 0  # line text started, before stripping boilerplate and/or head
+        self.footnotes = ''  # footnotes text, if extracted
 
     def load(self, filename):
-        pass
+        """Load a file (text or html)
+        Args:
+            filename: file pathname
+        Vars:
+            self.text = contents of file
+            self.basename = file base name
+        Raises:
+            IOError: unable to open file
+            SyntaxError: file too short
+        """
+        self.basename = os.path.basename(filename)
+        try:
+            with open(filename, 'r', encoding='utf-8') as file:
+                self.text = file.read()
+        except UnicodeError:
+            with open(filename, 'r', encoding='latin-1') as file:
+                self.text = file.read()
+        except FileNotFoundError as ex:
+            raise FileNotFoundError("Cannot load file: " + filename) from ex
+        if len(self.text) < 10:
+            raise SyntaxError("File is too short: " + filename)
 
-    def process_args(self, args):
-        """Process command line arguments"""
-        pass
+    def strip_pg_boilerplate(self):
+        """Remove the PG header and footer from the text if present."""
+        raise NotImplementedError("Override this method")
 
-    def analyze(self):
-        pass
-
-    def extract_footnotes(self):
-        """Extract the footnotes."""
-        pass
-
-    def transform(self):
-        """Final transformation pass."""
-        pass
+    def cleanup(self):
+        """Remove tags from the file"""
+        raise NotImplementedError("Override this method")
 
 
-
-
-class pgdp_file_text(pgdp_file):
+class PgdpFileText(PgdpFile):
+    """Store and process a DP text file"""
 
     def __init__(self, args):
         super().__init__(args)
-        self.from_pgdp_rounds = False
-        self.char_text = None
+        self.from_pgdp_rounds = False  # THIS file is from proofing rounds
 
     def load(self, filename):
         """Load the file"""
-        self.myfile.load_text(filename)
-        self.from_pgdp_rounds = self.myfile.basename.startswith('projectID')
+        if not filename.lower().endswith('.txt'):
+            raise SyntaxError("Not a text file: " + filename)
+        super().load(filename)
 
-    def analyze(self):
-        """Clean then analyse the content of a file. Decides if it is PP version,
-        a DP version, ..."""
-
-        # Remember which line the text started
-        self.start_line = self.myfile.start
-
-        # Unsplit lines
-        self.text = '\n'.join(self.myfile.text)
-
-        # Keep a copy to search for characters
-        self.char_text = self.text
-
-        # Check for œ, or [oe]
-        if self.text.find('œ') != -1 or self.text.find('Œ') != -1:
-            self.has_oe_ligature = True
-        elif self.text.find('[oe]') != -1 or self.text.find('[OE]') != -1:
-            self.has_oe_dp = True
-
-
-    def convert(self):
-        """Remove markers from the text."""
-
-        if self.args.txt_cleanup_type == "n":
-            return
-
-        if self.from_pgdp_rounds:
-            # Clean proofers
-            self.text = re.sub(r"-----File: \w+.png.*", '', self.text)
-
-        if self.args.txt_cleanup_type == "p":
-            # Proofers only. Done.
-            return
-
-        # Clean all.
-        if self.from_pgdp_rounds:
-            self.text = self.text.replace("\n/*\n", '\n\n')
-            self.text = self.text.replace("\n*/\n", '\n\n')
-            self.text = self.text.replace("\n/#\n", '\n\n')
-            self.text = self.text.replace("\n#/\n", '\n\n')
-            self.text = self.text.replace("\n/P\n", '\n\n')
-            self.text = self.text.replace("\nP/\n", '\n\n')
-
-            if self.args.ignore_format:
-                self.text = self.text.replace("<i>", "")
-                self.text = self.text.replace("</i>", "")
+    def strip_pg_boilerplate(self):
+        """Remove the PG header and footer from the text if present."""
+        new_text = []
+        start_found = False
+        for lineno, line in enumerate(self.text.splitlines(), start=1):
+            # Find the markers. Unfortunately PG lacks consistency
+            if line.startswith(PG_EBOOK_START):
+                start_found = True
+            if start_found and line.endswith("***"):  # may take multiple lines
+                new_text = []  # PG found, remove previous lines
+                self.start_line = lineno + 1
+                start_found = False
+            elif line.startswith(PG_EBOOK_END):
+                break  # ignore following lines
             else:
-                self.text = self.text.replace("<i>", "_")
-                self.text = self.text.replace("</i>", "_")
+                new_text.append(line)
+        self.text = '\n'.join(new_text)
 
-            self.text = re.sub("<.*?>", '', self.text)
-            self.text = re.sub("</.*?>", '', self.text)
-            self.text = re.sub(r"\[Blank Page\]", '', self.text)
+    def remove_paging(self):
+        """Remove page markers & blank pages"""
+        self.text = re.sub(r"-----File: \w+.png.*", '', self.text)
+        self.text = self.text.replace("[Blank Page]", '')
 
-            if self.args.suppress_proofers_notes:
-                self.text = re.sub(r"\[\*\*[^]]*?\]", '', self.text)
+    def remove_block_markup(self):
+        """Remove block markup"""
+        for markup in ['/*', '*/', '/#', '#/', '/P', 'P/', '/F', 'F/', '/X', 'X/']:
+            self.text = self.text.replace('\n' + markup + '\n', '\n\n')
 
-            if self.args.regroup_split_words:
-                self.text = re.sub(r"(\w+)-\*(\n+)\*", r'\2\1', self.text)
-                self.text = re.sub(r"(\w+)-\*_(\n\n)_\*", r"\2\1", self.text)
-                self.text = re.sub(r"(\w+)-\*(\w+)", r"\1\2", self.text)
-
+    def remove_formatting(self):
+        """Ignore or replace italics and bold tags in file from rounds"""
+        if self.args.ignore_format:
+            for tag in ['<i>', '</i>', '<b>', '</b>']:
+                self.text = self.text.replace(tag, '')
         else:
-            if self.args.ignore_format:
-                self.text = self.text.replace("_", "")
+            for tag in ['<i>', '</i>']:
+                self.text = self.text.replace(tag, '_')
+            for tag in ['<b>', '</b>']:
+                self.text = self.text.replace(tag, self.args.css_bold)
+        # remove other markup
+        self.text = re.sub('<.*?>', '', self.text)
 
-            # Horizontal separation
-            self.text = self.text.replace("*       *       *       *       *", "")
-            self.text = self.text.replace("*     *     *     *     *", "")
+    def suppress_proofers_notes(self):
+        """suppress proofers notes in file from rounds"""
+        if self.args.suppress_proofers_notes:
+            self.text = re.sub(r"\[\*\*[^]]*?]", '', self.text)
 
+    def regroup_split_words(self):
+        """Regroup split words, must run remove page markers 1st"""
+        if self.args.regroup_split_words:
+            word_splits = {r"(\w+)-\*(\n+)\*": r"\n\1",  # followed by 0 or more blank lines
+                           r"(\w+)-\*(\w+)": r"\1\2"}  # same line
+            for key, value in word_splits.items():
+                self.text = re.sub(key, value, self.text)
 
-        # Remove [Footnote, [Illustrations and [Sidenote tags
+    def ignore_format(self):
+        """Remove italics and bold markers in proofed file"""
+        if self.args.ignore_format:
+            self.text = re.sub(r"_((.|\n)+?)_", r'\1', self.text)
+            self.text = re.sub(r"=((.|\n)+?)=", r'\1', self.text)
+
+    def remove_thought_breaks(self):
+        """Remove thought breaks (5 spaced asterisks)"""
+        self.text = re.sub(r"\n\s+\*\s+\*\s+\*\s+\*\s+\*\s+\n", '\n\n', self.text)
+        self.text = re.sub(r"\n\s+•\s+•\s+•\s+•\s+•\s+", '\n\n', self.text)
+
+    def suppress_footnote_tags(self):
+        """Remove footnote tags"""
         if self.args.ignore_format or self.args.suppress_footnote_tags:
-            self.text = re.sub(r"\[Footnote (\d+): ", r'\1 ', self.text)
-            self.text = re.sub(r"\*\[Footnote: ", '', self.text)
+            self.text = re.sub(r"[\[]*Footnote ([\d\w]+):\s([^]]*?)[\]]*", r"\1 \2", self.text,
+                               flags=re.MULTILINE)
+            self.text = re.sub(r"\*\[Footnote:\s([^]]*?)]", r'\1', self.text, flags=re.MULTILINE)
 
+    def suppress_illustration_tags(self):
+        """Remove illustration tags"""
         if self.args.ignore_format or self.args.suppress_illustration_tags:
-            self.text = re.sub(r"\[Illustrations?:([^]]*?)\]", r'\1', self.text, flags=re.MULTILINE)
-            self.text = re.sub(r"\[Illustration\]", '', self.text)
+            self.text = re.sub(r"\[Illustration?:([^]]*?)]", r'\1', self.text, flags=re.MULTILINE)
+            self.text = self.text.replace("[Illustration]", '')
 
+    def suppress_sidenote_tags(self):
+        """Remove sidenote tags"""
         if self.args.ignore_format or self.args.suppress_sidenote_tags:
-            self.text = re.sub(r"\[Sidenote:([^]]*?)\]", r'\1', self.text, flags=re.MULTILINE)
+            self.text = re.sub(r"\[Sidenote:([^]]*?)]", r'\1', self.text, flags=re.MULTILINE)
 
-        # Replace -- with real mdash
-        self.text = self.text.replace("--", "—")
+    @staticmethod
+    def match_to_superscript(match):
+        """Convert regex match to subscript"""
+        return to_superscript(match.group(1))
 
+    def superscripts(self):
+        """Convert ^{} tagged text"""
+        self.text = re.sub(r"\^{?([\w\d]+)}?", PgdpFileText.match_to_superscript, self.text)
+
+    @staticmethod
+    def match_to_subscript(match):
+        """Convert regex match to subscript"""
+        return to_subscript(match.group(1))
+
+    def subscripts(self):
+        """Convert _{} tagged text"""
+        self.text = re.sub(r"_{([\w\d]+)}", PgdpFileText.match_to_subscript, self.text)
+
+    def cleanup(self):
+        """Perform cleanup for this type of file"""
+        if self.from_pgdp_rounds:
+            if self.args.txt_cleanup_type == 'n':  # none
+                return
+            # remove page markers & blank pages
+            self.remove_paging()
+            if self.args.txt_cleanup_type == 'p':  # proofers, all done
+                return
+            # else 'b' best effort
+            self.remove_block_markup()
+            self.remove_formatting()
+            self.suppress_proofers_notes()
+            self.regroup_split_words()
+        else:  # processed text file
+            self.strip_pg_boilerplate()
+            self.ignore_format()
+            self.remove_thought_breaks()
+
+        # all text files
+        if self.args.extract_footnotes:
+            if self.from_pgdp_rounds:  # always [Footnote 1: text]
+                self.extract_footnotes_pgdp()
+            else:  # probably [1] text
+                self.extract_footnotes_pp()
+        else:
+            self.suppress_footnote_tags()
+        self.suppress_illustration_tags()
+        self.suppress_sidenote_tags()
+        self.superscripts()
+        self.subscripts()
 
     def extract_footnotes_pgdp(self):
-        # Extract the footnotes from an F round
-        # Start with [Footnote ... and finish with ] at the end of a line
-
-        # Note: this is really dirty code. Should rewrite. Don't use
-        # cur_fnote[0].
-
-        in_fnote = False        # currently processing a footnote
-        cur_fnote = []          # keeping current footnote
-        text = []               # new text without footnotes
+        """ Extract the footnotes from an F round text file
+        Start with [Footnote #: and finish with ] at the end of a line
+        """
+        in_footnote = False  # currently processing a footnote
+        text = []  # new text without footnotes
         footnotes = []
 
         for line in self.text.splitlines():
-
-            # New footnote
-            if "[Footnote" in line:
-
-                if "*[Footnote" in line:
-                    # Join to previous - Remove the last from the existing
-                    # footnotes.
-                    line = line.replace("*[Footnote: ", "")
-                    cur_fnote, footnotes = footnotes[-1], footnotes[:-1]
-                else:
-                    line = re.sub(r"\[Footnote \d+: ", "", line)
-                    cur_fnote = [-1, ""]
-
-                in_fnote = True
-
-            if in_fnote:
-                cur_fnote[1] = "\n".join([cur_fnote[1], line])
-
-                # Footnote continuation: ] or ]*
-                # We don't try to regroup yet
-                if line.endswith(']'):
-                    cur_fnote[1] = cur_fnote[1][:-1]
-                    footnotes.append(cur_fnote)
-                    in_fnote = False
-                elif line.endswith("]*"):
-                    cur_fnote[1] = cur_fnote[1][:-2]
-                    footnotes.append(cur_fnote)
-                    in_fnote = False
-
+            if '[Footnote' in line:  # New footnote?
+                in_footnote = True
+                if '*[Footnote' not in line:  # Join to previous?
+                    footnotes.append('')  # start new footnote
+                line = re.sub(r'\*?\[Footnote\s?[\w\d]*:\s?', '', line)
+            if in_footnote:  # Inside a footnote?
+                footnotes[-1] = '\n'.join([footnotes[-1], line])
+                if line.endswith(']'):  # End of footnote?
+                    footnotes[-1] = footnotes[-1][:-1]
+                    in_footnote = False
+                elif line.endswith(']*'):  # Footnote continuation
+                    footnotes[-1] = footnotes[-1][:-2]
+                    in_footnote = False
             else:
                 text.append(line)
 
-        # Rebuild text, now without footnotes
-        self.text = '\n'.join(text)
-        self.footnotes = "\n".join([x[1] for x in footnotes])
-
+        self.text = '\n'.join(text)  # Rebuild text, now without footnotes
+        self.footnotes = '\n'.join(footnotes)
 
     def extract_footnotes_pp(self):
-        # Extract the footnotes from a PP text version
-        # Convert to lines and back
-        text, footnotes = extract_footnotes_pp(self.text.splitlines(), None)
+        """Extract footnotes from a PP text file. Text is iterable. Returns the text as an iterable,
+        without the footnotes, and footnotes as a list of (footnote string id, line number of the
+        start of the footnote, list of strings comprising the footnote). fn_regexes is a list of
+        (regex, fn_type) that identify the beginning and end of a footnote. The fn_type is 1 when
+        a ] terminates it, or 2 when a new block terminates it.
+        """
+        fn_regexes = [(r"\s*\[([\w-]+)\]\s*(.*)", 1),
+                      (r"(\s*)\[Note (\d+):( .*|$)", 2),
+                      (r"(      )Note (\d+):( .*|$)", 1)]
+        regex_count = [0] * len(fn_regexes)  # i.e. [0, 0, 0]
+        text_lines = self.text.splitlines()
+        for block, empty_lines in self.get_block(text_lines):
+            if not block:
+                continue
+            for i, (regex, fn_type) in enumerate(fn_regexes):
+                matches = re.match(regex, block[0])
+                if matches:
+                    regex_count[i] += 1
+                    break
+        # Pick the regex with the most matches
+        fn_regexes = [fn_regexes[regex_count.index(max(regex_count))]]
 
+        # Different types of footnote. 0 means not in footnote.
+        cur_fn_type, cur_fn_indent = 0, 0
+        footnotes = []
+        text = []
+        prev_block = None
+
+        for block, empty_lines in self.get_block(text_lines):
+            # Is the block a new footnote?
+            next_fn_type = 0
+            if len(block):
+                for (regex, fn_type) in fn_regexes:
+                    matches = re.match(regex, block[0])
+                    if matches:
+                        if matches.group(2).startswith('Illustration'):
+                            # An illustration, possibly inside a footnote. Treat
+                            # as part of text or footnote.
+                            continue
+                        next_fn_type = fn_type
+                        # Update first line of block, because we want the number outside.
+                        block[0] = matches.group(3)
+                        break
+
+            # Try to close previous footnote
+            next_fn_indent = None
+            if cur_fn_type:
+                if next_fn_type:
+                    # New block is footnote, so it ends the previous footnote
+                    footnotes += prev_block + ['']
+                    text += [''] * (len(prev_block) + 1)
+                    cur_fn_type, cur_fn_indent = next_fn_type, next_fn_indent
+                elif block[0].startswith(cur_fn_indent):
+                    # Same indent or more. This is a continuation. Merge with one empty line.
+                    block = prev_block + [''] + block
+                else:
+                    # End of footnote - current block is not a footnote
+                    footnotes += prev_block + ['']
+                    text += [''] * (len(prev_block) + 1)
+                    cur_fn_type = 0
+            if not cur_fn_type and next_fn_type:
+                # Account for new footnote
+                cur_fn_type, cur_fn_indent = next_fn_type, next_fn_indent
+            if cur_fn_type and (empty_lines >= 2 or
+                                (cur_fn_type == 2 and block[-1].endswith("]"))):
+                # End of footnote
+                if cur_fn_type == 2 and block[-1].endswith("]"):
+                    # Remove terminal bracket
+                    block[-1] = block[-1][:-1]
+                footnotes += block
+                text += [''] * (len(block))
+                cur_fn_type = 0
+                block = None
+            if not cur_fn_type:
+                # Add to text, with white lines
+                text += (block or []) + [''] * empty_lines
+                footnotes += [''] * (len(block or []) + empty_lines)
+
+            prev_block = block
         # Rebuild text, now without footnotes
         self.text = '\n'.join(text)
         self.footnotes = '\n'.join(footnotes)
 
+    @staticmethod
+    def get_block(pp_text):
+        """Generator to get a block of text, followed by the number of empty lines."""
+        empty_lines = 0
+        block = []
+        for line in pp_text:
+            if len(line):
+                if empty_lines:  # one or more empty lines will stop a block
+                    yield block, empty_lines
+                    block = []
+                    empty_lines = 0
+                block += [line]
+            else:
+                empty_lines += 1
+        yield block, empty_lines
 
-    def extract_footnotes(self):
-        if self.from_pgdp_rounds:
-            self.extract_footnotes_pgdp()
-        else:
-            self.extract_footnotes_pp()
 
-
-    def transform(self):
-        """Final cleanup."""
-        for func in self.transform_func:
-            self.text = func(self.text)
-
-        # Apply transform function to the footnotes
-        for func in self.transform_func:
-            self.footnotes = func(self.footnotes)
-
-
-class pgdp_file_html(pgdp_file):
+class PgdpFileHtml(PgdpFile):
+    """Store and process a DP html file."""
 
     def __init__(self, args):
         super().__init__(args)
+        self.tree = None
+        self.mycss = ''
 
-        self.mycss = ""
-        self.char_text = None
+    def parse_html5(self):
+        """Parse an HTML5 doc"""
+        # ignore warning caused by "xml:lang"
+        warnings.filterwarnings('ignore', message='Coercing non-XML name: xml:lang')
+        # don't include namespace in elements
+        myparser = html5parser.HTMLParser(namespaceHTMLElements=False)
+        # without parser this works for all html, but we have to remove namespace
+        # & don't get the errors list
+        tree = html5parser.document_fromstring(self.text, parser=myparser)
+        return tree.getroottree(), myparser.errors
 
+    def parse_html(self):
+        """Parse a non-HTML5 doc"""
+        myparser = etree.HTMLParser()
+        tree = etree.fromstring(self.text, parser=myparser)
+        # HTML parser rejects tags with both id and name: (513 == DTD_ID_REDEFINED)
+        # even though https://www.w3.org/TR/html4/struct/links.html#edef-A says it is OK
+        errors = [x for x in myparser.error_log
+                  if myparser.error_log[0].type != 513]
+        return tree.getroottree(), errors
 
     def load(self, filename):
-        """Load the file"""
-        self.myfile.load_xhtml(filename, relax=True)
+        """Load the file. If parsing succeeded, then self.tree is set, and parser.errors is []"""
+        if not filename.lower().endswith(('.html', '.htm', '.xhtml')):
+            raise SyntaxError('Not an html file: ' + filename)
+        super().load(filename)
+        try:
+            if 0 <= self.text.find('<!DOCTYPE html>', 0, 100):  # limit search
+                self.tree, errors = self.parse_html5()
+            else:
+                self.tree, errors = self.parse_html()
+        except Exception as ex:
+            raise SyntaxError('File cannot be parsed: ' + filename) from ex
+        if errors:
+            for error in errors:
+                print(error)
+            raise SyntaxError('Parsing errors in document: ' + filename)
 
+        # save line number of <body> tag - actual text start
+        # html5parser does not fill in the source line number
+        for lineno, line in enumerate(self.text.splitlines(), start=-1):
+            if '<body' in line:
+                self.start_line = lineno
+                break
 
-    def process_args(self, args):
-        # Load default CSS for transformations
-        if args.css_no_default is False:
-            self.mycss = DEFAULT_TRANSFORM_CSS
+        # remove the head - we only want the body
+        head = self.tree.find('head')
+        if head is not None:
+            head.getparent().remove(head)
 
-        # Process command line arguments
-        if self.args.css_smcap == 'U':
-            self.mycss += ".smcap { text-transform:uppercase; }"
-        elif self.args.css_smcap == 'L':
-            self.mycss += ".smcap { text-transform:lowercase; }"
-        elif self.args.css_smcap == 'T':
-            self.mycss += ".smcap { text-transform:capitalize; }"
+    def strip_pg_boilerplate(self):
+        """Remove the PG header and footer from the text if present."""
+        if -1 == self.text.find(PG_EBOOK_START):
+            return
+        # start: from <body to <div>*** START OF THE ...</div>
+        # end: from <div>*** END OF THE ...</div> to </body
+        start_found = False
+        end_found = False
+        for node in self.tree.find('body').iter():
+            if node.tag == 'div' and node.text and node.text.startswith(PG_EBOOK_START):
+                start_found = True
+                node.text = ''
+                node.tail = ''
+            elif node.tag == 'div' and node.text and node.text.startswith(PG_EBOOK_END):
+                end_found = True
+            if end_found or not start_found:
+                node.text = ''
+                node.tail = ''
+        # we need the start line, html5parser does not save source line
+        for lineno, line in enumerate(self.text.splitlines(), start=1):
+            if PG_EBOOK_START in line:
+                self.start_line = lineno + 1
+                break
 
-        if self.args.css_bold:
-            self.mycss += "b:before, b:after { content: " + self.args.css_bold + "; }"
+    def css_smallcaps(self):
+        """Transform small caps"""
+        transforms = {'U': 'uppercase',
+                      'L': 'lowercase',
+                      'T': 'capitalize'}
+        if self.args.css_smcap in transforms:
+            self.mycss += f".smcap {{ text-transform:{transforms[self.args.css_smcap]}; }}"
 
-        if self.args.css_greek_title_plus:
-            # greek: if there is a title, use it to replace the greek. */
-            self.mycss += '*[lang=grc] { content: "+" attr(title) "+"; }'
+    def css_bold(self):
+        """Surround bold strings with this string"""
+        self.mycss += 'b::before, b::after { content: "' + self.args.css_bold + '"; }'
 
+    def css_illustration(self):
+        """Add [Illustration: ...] markup"""
         if self.args.css_add_illustration:
             for figclass in ['figcenter', 'figleft', 'figright']:
-                self.mycss += '.' + figclass + ':before { content: "[Illustration: "; }'
-                self.mycss += '.' + figclass + ':after { content: "]"; }'
+                self.mycss += '.' + figclass + '::before { content: "[Illustration: "; }'
+                self.mycss += '.' + figclass + '::after { content: "]"; }'
 
+    def css_sidenote(self):
+        """Add [Sidenote: ...] markup"""
         if self.args.css_add_sidenote:
-            self.mycss += '.sidenote:before { content: "[Sidenote: "; }'
-            self.mycss += '.sidenote:after { content: "]"; }'
+            self.mycss += '.sidenote::before { content: "[Sidenote: "; }'
+            self.mycss += '.sidenote::after { content: "]"; }'
 
-        # --css can be present multiple times, so it's a list.
+    def css_greek_title_plus(self):
+        """Greek: if there is a title, use it to replace the (grc=ancient) Greek."""
+        if self.args.css_greek_title_plus:
+            self.mycss += '*[lang=grc] { content: "+" attr(title) "+"; }'
+
+    def css_custom_css(self):
+        """--css can be present multiple times, so it's a list"""
         for css in self.args.css:
             self.mycss += css
 
+    def remove_nbspaces(self):
+        """Remove non-breakable spaces between numbers. For instance, a
+        text file could have 250000, and the html could have 250 000.
+        """
+        # Todo: &nbsp;, &#160;, &#x00A0;?
+        if self.args.suppress_nbsp_num:
+            self.text = re.sub(r"(\d)\u00A0(\d)", r"\1\2", self.text)
 
-    def analyze(self):
-        """Clean then analyse the content of a file."""
-        # Empty the head - we only want the body
-        self.myfile.tree.find('head').clear()
+    def remove_soft_hyphen(self):
+        """Suppress shy (soft hyphen)"""
+        # Todo: &#173;, &#x00AD;?
+        self.text = re.sub(r"\u00AD", r"", self.text)
 
-        # Remember which line <body> was.
-        self.start_line = self.myfile.tree.find('body').sourceline - 2
+    def cleanup(self):
+        """Perform cleanup for this type of file - build up a list of CSS transform rules,
+        process them against tree, then convert to text.
+        """
+        self.strip_pg_boilerplate()
+        # load default CSS for transformations
+        if not self.args.css_no_default:
+            self.mycss = DEFAULT_TRANSFORM_CSS
+        self.css_smallcaps()
+        self.css_bold()
+        self.css_illustration()
+        self.css_sidenote()
+        self.css_custom_css()
+        self.process_css()  # process transformations
 
-        # Remove PG footer, 1st method
-        clear_after = False
-        for element in self.myfile.tree.find('body').iter():
-            if clear_after:
-                element.text = ""
-                element.tail = ""
-            elif element.tag == "p" and element.text and element.text.startswith("***END OF THE PROJECT GUTENBERG EBOOK"):
-                element.text = ""
-                element.tail = ""
-                clear_after = True
-
-        # Remove PG header and footer, 2nd method
-        find = etree.XPath("//pre")
-        for element in find(self.myfile.tree):
-            if element.text is None:
-                continue
-
-            text = element.text.strip()
-
-            # Header - Remove everything until start of book.
-            m = re.match(r".*?\*\*\* START OF THIS PROJECT GUTENBERG EBOOK.*?\*\*\*(.*)", text, flags=re.MULTILINE | re.DOTALL)
-            if m:
-                # Found the header. Keep only the text after the
-                # start tag (usually the credits)
-                element.text = m.group(1)
-                continue
-
-            if text.startswith("End of the Project Gutenberg") or text.startswith("End of Project Gutenberg"):
-                clear_element(element)
-
-        # Remove PG footer, 3rd method -- header and footer are normal
-        # html, not text in <pre> tag.
-        try:
-            # Look for one element
-            (element,) = etree.XPath("//p[@id='pg-end-line']")(self.myfile.tree)
-            while element is not None:
-                clear_element(element)
-                element = element.getnext()
-        except ValueError:
-            pass
-
-        # Cleaning is done.
+        self.extract_footnotes()
 
         # Transform html into text for character search.
-        self.char_text = etree.XPath("normalize-space(/)")(self.myfile.tree)
+        self.text = etree.XPath("string(/)")(self.tree)
 
-        # HTML doc should have oelig by default.
-        self.has_oe_ligature = True
+        self.remove_nbspaces()
+        self.remove_soft_hyphen()
 
+    @staticmethod
+    def _text_transform(val, errors: list):
+        """Transform smcaps"""
+        if len(val.value) != 1:
+            errors += [(val.line, val.column, val.name + " takes 1 argument")]
+        else:
+            value = val.value[0].value
+            if value == 'uppercase':
+                return lambda x: x.upper()
+            if value == 'lowercase':
+                return lambda x: x.lower()
+            if value == 'capitalize':
+                return lambda x: x.title()
+            if value == 'superscript':
+                return lambda x: to_superscript(x)
+            if value == 'subscript':
+                return lambda x: to_subscript(x)
+            errors += [(val.line, val.column,
+                        val.name + " accepts only 'uppercase', 'lowercase', 'capitalize',"
+                                   " 'superscript', or 'subscript'")]
+        return None
 
-    def text_apply(self, element, func):
-        """Apply a function to every sub element's .text and .tail,
-        and element's .text."""
-        if element.text:
-            element.text = func(element.text)
-        for el in element.iter():
-            if el == element:
-                continue
-            if el.text:
-                el.text = func(el.text)
-            if el.tail:
-                el.tail = func(el.tail)
+    @staticmethod
+    def _text_replace(val, errors: list):
+        """Skip S (spaces) tokens"""
+        values = [v for v in val.value if v.type != "S"]
+        if len(values) != 2:
+            errors += [(val.line, val.column, val.name + " takes 2 string arguments")]
+            return None
+        return lambda x: x.replace(values[0].value, values[1].value)
 
+    @staticmethod
+    def _text_move(val, errors: list):
+        """Move a node"""
+        values = [v for v in val.value if v.type != "S"]
+        if len(values) < 1:
+            errors += [(val.line, val.column, val.name + " takes at least one argument")]
+            return None
+        f_move = []
+        for value in values:
+            if value.value == 'parent':
+                f_move.append(lambda el: el.getparent())
+            elif value.value == 'prev-sib':
+                f_move.append(lambda el: el.getprevious())
+            elif value.value == 'next-sib':
+                f_move.append(lambda el: el.getnext())
+            else:
+                errors += [(val.line, val.column, val.name + " invalid value " + value.value)]
+                f_move = None
+                break
+        return f_move
 
-    def convert(self):
-        """Remove HTML and PGDP marker from the text."""
-
-        escaped_unicode_re = re.compile(r"\\u[0-9a-fA-F]{4}")
-        def escaped_unicode(m):
-            try:
-                newstr = bytes(m.group(0), 'utf8').decode('unicode-escape')
-            except Exception:
-                newstr = m.group(0)
-
-            return newstr
-
-        def new_content(element):
-            """Process the "content:" property
-            """
-            retstr = ""
-            for token in val.value:
-                if token.type == "STRING":
-                    # e.g. { content: "xyz" }
-                    retstr += escaped_unicode_re.sub(escaped_unicode, token.value)
-                elif token.type == "FUNCTION":
-                    if token.function_name == 'attr':
-                        # e.g. { content: attr(title) }
-                        retstr += element.attrib.get(token.content[0].value, "")
-                elif token.type == "IDENT":
-                    if token.value == "content":
-                        # Identity, e.g. { content: content }
-                        retstr += element.text
-
-            return retstr
-
-
-        # Process each rule from our transformation CSS
+    def process_css(self):
+        """Process each rule from our transformation CSS"""
         stylesheet = tinycss.make_parser().parse_stylesheet(self.mycss)
         property_errors = []
-        for rule in stylesheet.rules:
 
-            # Extract values we care about
+        def _move_element(elem, move_list):
+            """Move elem in tree"""
+            parent = elem.getparent()
+            new = elem
+            for item in move_list:
+                new = item(new)
+            # move the tail to the sibling or the parent
+            if elem.tail:
+                sibling = elem.getprevious()
+                if sibling:
+                    sibling.tail = (sibling.tail or '') + elem.tail
+                else:
+                    parent.text = (parent.text or '') + elem.tail
+                elem.tail = None
+            # prune and graft
+            parent.remove(elem)
+            new.append(elem)
+
+        def _process_element(elem, val):
+            """replace text with content of an attribute."""
+            if val.name == 'content':
+                v_content = self.new_content(elem, val)
+                if selector.pseudo_element == 'before':
+                    elem.text = v_content + (elem.text or '')  # opening tag
+                elif selector.pseudo_element == 'after':
+                    elem.tail = v_content + (elem.tail or '')  # closing tag
+                else:  # replace all content
+                    elem.text = self.new_content(elem, val)
+            elif f_replace_with_attr:
+                elem.text = f_replace_with_attr(elem)
+            elif f_transform:
+                self.text_apply(elem, f_transform)
+            elif f_element_func:
+                f_element_func(elem)
+            elif f_move:
+                _move_element(elem, f_move)
+
+        for rule in stylesheet.rules:
+            # extract values we care about
             f_transform = None
             f_replace_with_attr = None
-            #f_replace_regex = None
-            f_text_replace = None
             f_element_func = None
-            f_move = None
+            f_move = []
 
-            for val in rule.declarations:
-
-                if val.name == 'content':
-                    # result depends on element and pseudo elements.
-                    pass
-
-                elif val.name == "text-transform":
-                    if len(val.value) != 1:
-                        property_errors += [(val.line, val.column, val.name + " takes 1 argument")]
-                    else:
-                        v = val.value[0].value
-                        if v == "uppercase":
-                            f_transform = lambda x: x.upper()
-                        elif v == "lowercase":
-                            f_transform = lambda x: x.lower()
-                        elif v == "capitalize":
-                            f_transform = lambda x: x.title()
-                        else:
-                            property_errors += [(val.line, val.column, val.name + " accepts only 'uppercase', 'lowercase' or 'capitalize'")]
-
-                elif val.name == "_replace_with_attr":
-                    f_replace_with_attr = lambda el: el.attrib[val.value[0].value]
-
-                elif val.name == "text-replace":
-                    # Skip S (spaces) tokens.
-                    values = [v for v in val.value if v.type != "S"]
-                    if len(values) != 2:
-                        property_errors += [(val.line, val.column, val.name + " takes 2 string arguments")]
-                    else:
-                        v1 = values[0].value
-                        v2 = values[1].value
-                        f_text_replace = lambda x: x.replace(v1, v2)
-
-                elif val.name == "display":
-                    # Support display none only. So ignore "none" argument.
-                    f_element_func = clear_element
-
-                elif val.name == "_graft":
-                    values = [v for v in val.value if v.type != "S"]
-                    if len(values) < 1:
-                        property_errors += [(val.line, val.column, val.name + " takes at least one argument")]
-                        continue
-                    f_move = []
-                    for v in values:
-                        print("[", v.value, "]")
-                        if v.value == 'parent':
-                            f_move.append(lambda el: el.getparent())
-                        elif v.value == 'prev-sib':
-                            f_move.append(lambda el: el.getprevious())
-                        elif v.value == 'next-sib':
-                            f_move.append(lambda el: el.getnext())
-                        else:
-                            property_errors += [(val.line, val.column, val.name + " invalid value " + v.value)]
-                            f_move = None
-                            break
-
-                    if not f_move:
-                        continue
-
-#                elif val.name == "_replace_regex":
-#                    f_replace_regex = partial(re.sub, r"(\d)\u00A0(\d)", r"\1\2")
-#                    f_replace_regex = partial(re.sub, val.value[0].value, val.value[1].value)
-
+            for value in rule.declarations:
+                if value.name == 'content':
+                    pass  # result depends on element and pseudo elements
+                elif value.name == 'text-transform':
+                    f_transform = self._text_transform(value, property_errors)
+                elif value.name == 'text-replace':
+                    f_transform = self._text_replace(value, property_errors)
+                elif value.name == '_replace_with_attr':
+                    def f_replace_with_attr(elem):
+                        return elem.attrib[value.value[0].value]
+                elif value.name == 'display':
+                    # support display none only. So ignore "none" argument
+                    f_element_func = PgdpFileHtml.clear_element
+                elif value.name == '_graft':
+                    f_move = self._text_move(value, property_errors)
                 else:
-                    property_errors += [(val.line, val.column, "Unsupported property " + val.name)]
+                    property_errors += [(value.line, value.column, "Unsupported property "
+                                         + value.name)]
                     continue
 
-                # Iterate through each selectors in the rule
+                # iterate through each selector in the rule
                 for selector in cssselect.parse(rule.selector.as_css()):
-
-                    pseudo_element = selector.pseudo_element
-
                     xpath = cssselect.HTMLTranslator().selector_to_xpath(selector)
                     find = etree.XPath(xpath)
+                    # find each matching elem in the HTML document
+                    for element in find(self.tree):
+                        _process_element(element, value)
 
-                    # Find each matching element in the HTML/XHTML document
-                    for element in find(self.myfile.tree):
+        return self.css_errors(stylesheet.errors, property_errors)
 
-                        # Replace text with content of an attribute.
-                        if f_replace_with_attr:
-                            element.text = f_replace_with_attr(element)
-
-                        if val.name == 'content':
-                            v_content = new_content(element)
-                            if pseudo_element == "before":
-                                element.text = v_content + (element.text or '') # opening tag
-                            elif pseudo_element == "after":
-                                element.tail = v_content + (element.tail or '') # closing tag
-                            else:
-                                # Replace all content
-                                element.text = new_content(element)
-
-                        if f_transform:
-                            self.text_apply(element, f_transform)
-
-                        if f_text_replace:
-                            self.text_apply(element, f_text_replace)
-
-                        if f_element_func:
-                            f_element_func(element)
-
-                        if f_move:
-                            parent = element.getparent()
-                            new = element
-                            for f in f_move:
-                                new = f(new)
-
-                            # Move the tail to the sibling or the parent
-                            if element.tail:
-                                sibling = element.getprevious()
-                                if sibling:
-                                    sibling.tail = (sibling.tail or "") + element.tail
-                                else:
-                                    parent.text = (parent.text or "") + element.tail
-                                element.tail = None
-
-                            # Prune and graft
-                            parent.remove(element)
-                            new.append(element)
-
-                       # if f_replace_regex and element.text:
-                       #     element.text = f_replace_regex(element.text)
-
-
-        css_errors = ""
-        if stylesheet.errors or property_errors:
-            # There is transformation CSS errors. If the default css
-            # is included, take the offset into account.
+    def css_errors(self, stylesheet_errors, property_errors):
+        """Collect transformation CSS errors"""
+        css_errors = ''
+        if stylesheet_errors or property_errors:
+            css_errors = "<div class='error-border bbox'><p>Error(s) in the" \
+                         "  transformation CSS:</p><ul>"
             i = 0
-            if self.args.css_no_default is False:
+            # if the default css is included, take the offset into account
+            if not self.args.css_no_default:
                 i = DEFAULT_TRANSFORM_CSS.count('\n')
-            css_errors = "<div class='error-border bbox'><p>Error(s) in the transformation CSS:</p><ul>"
-            for err in stylesheet.errors:
-                css_errors += "<li>{0},{1}: {2}</li>".format(err.line-i, err.column, err.reason)
+            for err in stylesheet_errors:
+                css_errors += f"<li>{err.line - i},{err.column}: {err.reason}</li>"
             for err in property_errors:
-                css_errors += "<li>{0},{1}: {2}</li>".format(err[0]-i, err[1], err[2])
+                css_errors += f"<li>{err[0] - i},{err[1]}: {err[2]}</li>"
             css_errors += "</ul>"
-
         return css_errors
 
+    @staticmethod
+    def new_content(elem, val):
+        """Process the "content:" property"""
+
+        def _escaped_unicode(element):
+            try:
+                return bytes(element.group(0), 'utf8').decode('unicode-escape')
+            except UnicodeDecodeError:
+                return element.group(0)
+
+        escaped_unicode_re = re.compile(r"\\u[0-9a-fA-F]{4}")
+        result = ""
+        for token in val.value:
+            if token.type == "STRING":  # e.g. { content: "xyz" }
+                result += escaped_unicode_re.sub(_escaped_unicode, token.value)
+            elif token.type == "FUNCTION":
+                if token.function_name == 'attr':  # e.g. { content: attr(title) }
+                    result += elem.attrib.get(token.content[0].value, "")
+            elif token.type == "IDENT":
+                if token.value == "content":  # identity, e.g. { content: content }
+                    result += elem.text
+        return result
+
+    @staticmethod
+    def text_apply(tree_elem, func):
+        """Apply a function to every sub-element's .text and .tail, and element's .text"""
+        if tree_elem.text:
+            tree_elem.text = func(tree_elem.text)
+        for sub in tree_elem.iter():
+            if sub == tree_elem:
+                continue
+            if sub.text:
+                sub.text = func(sub.text)
+            if sub.tail:
+                sub.tail = func(sub.tail)
+
+    @staticmethod
+    def clear_element(element):
+        """In an XHTML tree, remove all sub-elements of a given element"""
+        tail = element.tail
+        element.clear()
+        element.tail = tail
 
     def extract_footnotes(self):
-        # Find footnotes, then remove them
+        """Extract the footnotes"""
 
-        def strip_note_tag(string, keep_num=False):
-            """Remove not tag and only keep the number.  For instance
-            "Note 123: lorem ipsum" becomes "123 lorem ipsum" or just
-            "lorem ipsum".
-            """
+        def strip_note_tag(string):
+            """Remove note tag and number. "Note 123: lorem ipsum" becomes "lorem ipsum"."""
             for regex in [r"\s*\[([\w-]+)\](.*)",
                           r"\s*([\d]+)\s+(.*)",
                           r"\s*([\d]+):(.*)",
                           r"\s*Note ([\d]+):\s+(.*)"]:
-                m = re.match(regex, string, re.DOTALL)
-                if m:
+                match = re.match(regex, string, re.DOTALL)
+                if match:
+                    return match.group(2)
+            return string  # That may be bad
+
+        if not self.args.extract_footnotes:
+            return
+        footnotes = []
+        # Special case for PPers who do not keep the marking around
+        # the whole footnote. They only mark the first paragraph.
+        elements = etree.XPath("//div[@class='footnote']")(self.tree)
+        if len(elements) == 1:
+            # remove footnote number & remove footnote from main document
+            footnotes += [strip_note_tag(elements[0].xpath("string()"))]
+            elements[0].getparent().remove(elements[0])
+        else:
+            for find in ["//div[@class='footnote']",
+                         "//div[@id[starts-with(.,'FN_')]]",
+                         "//p[a[@id[starts-with(.,'Footnote_')]]]",
+                         "//div/p[span/a[@id[starts-with(.,'Footnote_')]]]",
+                         "//p[@class='footnote']"]:
+                for element in etree.XPath(find)(self.tree):
+                    # remove footnote number & remove footnote from main document
+                    footnotes += [strip_note_tag(element.xpath("string()"))]
+                    element.getparent().remove(element)
+                if footnotes:  # found them, stop now
                     break
-
-            if m:
-                if keep_num:
-                    return m.group(1) + " " + m.group(2)
-                else:
-                    return m.group(2)
-            else:
-                # That may be bad
-                return string
-
-        if self.args.extract_footnotes:
-            footnotes = []
-
-            # Special case for PPers who do not keep the marking
-            # around the whole footnote. They only mark the first
-            # paragraph.
-            elements = etree.XPath("//div[@class='footnote']")(self.myfile.tree)
-            if len(elements) == 1:
-                element = elements[0]
-
-                # Clean footnote number
-                for el in element:
-                    footnotes += [strip_note_tag(el.xpath("string()"))]
-
-                # Remove the footnote from the main document
-                element.getparent().remove(element)
-            else:
-                for find in ["//div[@id[starts-with(.,'FN_')]]",
-                             #  "//div[p/a[@id[starts-with(.,'Footnote_')]]]",
-                             "//p[a[@id[starts-with(.,'Footnote_')]]]",
-                             "//div/p[span/a[@id[starts-with(.,'Footnote_')]]]",
-                             "//div/p[span/a[@id[starts-with(.,'Footnote_')]]]",
-                             #"//p[a[@id[not(starts-with(.,'footnotetag')) and starts-with(.,'footnote')]]]",
-                             #"//p[a[@id[starts-with(.,'footnote')]]]",
-                             "//p[@class='footnote']",
-                             "//div[@class='footnote']"]:
-                    for element in etree.XPath(find)(self.myfile.tree):
-
-                        # Grab the text and remove the footnote number
-                        footnotes += [strip_note_tag(element.xpath("string()"))]
-
-                        # Remove the footnote from the main document
-                        element.getparent().remove(element)
-
-                    if len(self.footnotes):
-                        # Found them. Stop now.
-                        break
-
-            self.footnotes = "\n".join(footnotes)
+        self.footnotes = "\n".join(footnotes)  # save as text string
 
 
-    def transform(self):
-        """Transform html into text. Do a final cleanup."""
-        self.text = etree.XPath("string(/)")(self.myfile.tree)
-
-#        ff=open("compfilehtml.txt", "w")
-#        ff.write(self.text)
-#        ff.close()
-
-        # Apply transform function to the main text
-        for func in self.transform_func:
-            self.text = func(self.text)
-
-        # Apply transform function to the footnotes
-        for func in self.transform_func:
-            self.footnotes = func(self.footnotes)
-
-        # zero width space
-        if self.args.ignore_0_space:
-            self.text = self.text.replace(chr(0x200b), "")
-
-
-class CompPP(object):
-    """Compare two files.
-    """
+class PPComp:
+    """Compare two files."""
 
     def __init__(self, args):
         self.args = args
 
-    def oelig_convert(self, convert_oelig, text):
-        # Do the required oelig conversion
-        if convert_oelig == 1:
-            text = text.replace(r"[oe]", "oe")
-            text = text.replace(r"[OE]", "OE")
-
-        elif convert_oelig == 2:
-            text = text.replace(r"[oe]", "œ")
-            text = text.replace(r"[OE]", "Œ")
-
-        elif convert_oelig == 3:
-            text = text.replace("œ", "oe")
-            text = text.replace("Œ", "OE")
-
-        return text
-
-    def latin1_convert(self, text):
-        # Convert some UTF8 characters to latin1
-        text = text.replace("’", "'")
-        text = text.replace("‘", "'")
-        text = text.replace('“', '"')
-        text = text.replace('”', '"')
-
-    #    text = text.replace('in-4º', 'in-4o')
-    #    text = text.replace('in-8º', 'in-8o')
-    #    text = text.replace('in-fº', 'in-fo')
-        text = text.replace('º', 'o')
-
-        return text
-
-
-    def convert_to_words(self, text):
-        """Split the text into a list of words from the text."""
-
-        # Split into list of words
-        words = []
-
-        for line in re.findall(r'([\w-]+|\W)', text):
-            line = line.strip()
-
-            if line != '':
-                words.append(line)
-
-        return words
-
-
-    def compare_texts(self, text1, text2, debug=False):
-        # Compare two sources
-        # We could have used the difflib module, but it's too slow:
-        #    for line in difflib.unified_diff(f1.words, f2.words):
-        #        print(line)
-        # Use diff instead.
-
-        # Some debug code
-        if False and debug:
-            f = open("/tmp/text1", "wb")
-            f.write(text1.encode('utf-8'))
-            f.close()
-            f = open("/tmp/text2", "wb")
-            f.write(text2.encode('utf-8'))
-            f.close()
-
-        with tempfile.NamedTemporaryFile(mode='wb') as t1, tempfile.NamedTemporaryFile(mode='wb') as t2:
-
-            t1.write(text1.encode('utf-8'))
-            t2.write(text2.encode('utf-8'))
-
-            t1.flush()
-            t2.flush()
-
-            repo_dir = os.environ.get("OPENSHIFT_DATA_DIR", "")
-            if repo_dir:
-                dwdiff_path = os.path.join(repo_dir, "bin", "dwdiff")
+    def do_process(self):
+        """Main routine: load & process the files"""
+        files = [None, None]
+        for i, fname in enumerate(self.args.filename):
+            if fname.lower().endswith(('.html', '.htm', '.xhtml')):
+                files[i] = PgdpFileHtml(self.args)
             else:
-                dwdiff_path = "dwdiff"
+                files[i] = PgdpFileText(self.args)
+            files[i].load(fname)
+            files[i].cleanup()  # perform cleanup for each type of file
 
+        # perform common cleanup for both files
+        self.check_characters(files)
+
+        # Compare the two versions
+        main_diff = self.compare_texts(files[0].text, files[1].text)
+        if self.args.extract_footnotes:
+            fnotes_diff = self.compare_texts(files[0].footnotes, files[1].footnotes)
+        else:
+            fnotes_diff = ""
+        html_content = self.create_html(files, main_diff, fnotes_diff)
+        return html_content, files[0].basename, files[1].basename
+
+    def compare_texts(self, text1, text2):
+        """Compare two sources, using dwdiff"""
+        with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8') as temp1, \
+                tempfile.NamedTemporaryFile(mode='w', encoding='utf-8') as temp2:
+            temp1.write(text1)
+            temp1.flush()
+            temp2.write(text2)
+            temp2.flush()
+            repo_dir = os.environ.get('OPENSHIFT_DATA_DIR', '')
+            if repo_dir:
+                dwdiff_path = os.path.join(repo_dir, 'bin', 'dwdiff')
+            else:
+                dwdiff_path = 'dwdiff'
+
+            # -P Use punctuation characters as delimiters.
+            # -R Repeat the begin and end markers at the start and end of line if a change crosses
+            #    a newline.
+            # -C 2 Show <num> lines of context before and after each changes.
+            # -L Show line numbers at the start of each line.
             cmd = [dwdiff_path,
                    "-P",
                    "-R",
@@ -775,459 +910,250 @@ class CompPP(object):
                    "-x ]COMPPP_STOP_DEL[",
                    "-y ]COMPPP_START_INS[",
                    "-z ]COMPPP_STOP_INS["]
-
             if self.args.ignore_case:
                 cmd += ["--ignore-case"]
-
-            cmd += [t1.name, t2.name]
-
-            # That shouldn't be needed if openshift was utf8 by default.
-            env = os.environ.copy()
-            env["LANG"] = "en_US.UTF-8"
-
-            p = subprocess.Popen(cmd,
-                                 stdout=subprocess.PIPE,
-                                 env=env)
-
-            # The output is raw, so we have to decode it to UTF-8, which
-            # is the default under Ubuntu.
-            return p.stdout.read().decode('utf-8')
-
+            cmd += [temp1.name, temp2.name]
+            with subprocess.Popen(cmd, stdout=subprocess.PIPE) as process:
+                return process.stdout.read().decode('utf-8')
 
     def create_html(self, files, text, footnotes):
+        """Create the output html file"""
 
-        def massage_input(text, start0, start1):
+        def massage_input(txt, start0, start1):
             # Massage the input
-            text = text.replace("&", "&amp;")
-            text = text.replace("<", "&lt;")
-            text = text.replace(">", "&gt;")
-
-            text = text.replace("]COMPPP_START_DEL[", "<del>")
-            text = text.replace("]COMPPP_STOP_DEL[", "</del>")
-            text = text.replace("]COMPPP_START_INS[", "<ins>")
-            text = text.replace("]COMPPP_STOP_INS[", "</ins>")
-
-            if text:
-                text = "<hr /><pre>\n" + text
-            text = text.replace("\n--\n", "\n</pre><hr /><pre>\n")
-
-            text = re.sub(r"^\s*(\d+):(\d+)",
-                          lambda m: "<span class='lineno'>{0} : {1}</span>".format(int(m.group(1)) + start0,
-                                                                                   int(m.group(2)) + start1),
-                          text, flags=re.MULTILINE)
-            if text:
-                text = text + "</pre>\n"
-
-
-            return text
+            replacements = {"&": "&amp;",
+                            "<": "&lt;",
+                            ">": "&gt;",
+                            "]COMPPP_START_DEL[": "<del>",
+                            "]COMPPP_STOP_DEL[": "</del>",
+                            "]COMPPP_START_INS[": "<ins>",
+                            "]COMPPP_STOP_INS[": "</ins>"}
+            newtext = txt
+            for key, value in replacements.items():
+                newtext = newtext.replace(key, value)
+            if newtext:
+                newtext = "<hr /><pre>\n" + newtext
+            newtext = newtext.replace("\n--\n", "\n</pre><hr /><pre>\n")
+            newtext = re.sub(r"^\s*(\d+):(\d+)",
+                             lambda m: f"<span class='lineno'>{int(m.group(1)) + start0}"
+                                       f" : {int(m.group(2)) + start1}</span>",
+                             newtext, flags=re.MULTILINE)
+            if newtext:
+                newtext += "</pre>\n"
+            return newtext
 
         # Find the number of diff sections
-        nb_diffs_text = 0
+        diffs_text = 0
         if text:
-            nb_diffs_text = len(re.findall("\n--\n", text)) + 1
-
-        nb_diffs_footnotes = 0
-        if footnotes:
-            nb_diffs_footnotes = len(re.findall("\n--\n", footnotes or "")) + 1
-
-        # Text, with correct (?) line numbers
-        text = massage_input(text, files[0].start_line, files[1].start_line)
-
-        # Footnotes - line numbers are meaningless right now. We could fix
-        # that.
-        footnotes = massage_input(footnotes, 0, 0)
-
+            diffs_text = len(re.findall("\n--\n", text)) + 1
+            # Text, with correct (?) line numbers
+            text = massage_input(text, files[0].start_line, files[1].start_line)
         html_content = "<div>"
-
-        if nb_diffs_text == 0:
+        if diffs_text == 0:
             html_content += "<p>There is no diff section in the main text.</p>"
-        elif nb_diffs_text == 1:
-            html_content += "<p>There is " + str(nb_diffs_text) + " diff section in the main text.</p>"
+        elif diffs_text == 1:
+            html_content += "<p>There is 1 diff section in the main text.</p>"
         else:
-            html_content += "<p>There are " + str(nb_diffs_text) + " diff sections in the main text.</p>"
+            html_content += f"<p>There are <b>{diffs_text}</b> diff sections in the main text.</p>"
 
         if footnotes:
+            diffs_footnotes = len(re.findall("\n--\n", footnotes or "")) + 1
+            # Footnotes - line numbers are meaningless right now. We could fix that.
+            footnotes = massage_input(footnotes, 0, 0)
             html_content += "<p>Footnotes are diff'ed separately <a href='#footnotes'>here</a></p>"
-            if nb_diffs_footnotes == 0:
+            if diffs_footnotes == 0:
                 html_content += "<p>There is no diff section in the footnotes.</p>"
-            elif nb_diffs_footnotes == 1:
-                html_content += "<p>There is " + str(nb_diffs_footnotes) + " diff section in the footnotes.</p>"
+            elif diffs_footnotes == 1:
+                html_content += "<p>There is 1 diff section in the footnotes.</p>"
             else:
-                html_content += "<p>There are " + str(nb_diffs_footnotes) + " diff sections in the footnotes.</p>"
+                html_content += f"<p>There are {diffs_footnotes}" \
+                                " diff sections in the footnotes.</p>"
         else:
             if self.args.extract_footnotes:
                 html_content += "<p>There is no diff section in the footnotes.</p>"
 
-        if nb_diffs_text:
-            html_content += "<h2 class='sep4'>Main text</h2>"
+        if diffs_text:
+            html_content += "<h2>Main text</h2>"
             html_content += text
-
         if footnotes:
-            html_content += "<h2 id='footnotes' class='sep4'>Footnotes</h2>"
-            html_content += "<pre class='sep4'>"
-            html_content += footnotes
-            html_content += "</pre>"
-
+            html_content += "<h2 id='footnotes'>Footnotes</h2>"
+            html_content += "<pre>" + footnotes + "</pre>"
         html_content += "</div>"
-
         return html_content
 
-
-    def check_char(self, files, char_best, char_other):
-        """Check whether each file has the best character. If not, add a
-        conversion request.
-
-        This is used for instance if one version uses ’ while the other
-        uses '. In that case, we need to convert one into the other, to
-        get a smaller diff.
-        """
-
-        in_0 = files[0].char_text.find(char_best)
-        in_1 = files[1].char_text.find(char_best)
-
-        if in_0 >= 0 and in_1 >= 0:
-            # Both have it
-            return
-
-        if in_0 == -1 and in_1 == -1:
-            # None have it
-            return
-
-        # Downgrade one version
-        if in_0 > 0:
-            files[0].transform_func.append(lambda text: text.replace(char_best, char_other))
-        else:
-            files[1].transform_func.append(lambda text: text.replace(char_best, char_other))
-
-
-    def check_oelig(self, files):
-        """Similar to check_char, but for oe ligatures."""
-        if files[0].has_oe_ligature and files[1].has_oe_ligature:
-            pass
-        elif files[0].has_oe_dp and files[1].has_oe_dp:
-            pass
-        elif files[0].has_oe_ligature and files[1].has_oe_dp:
-            files[1].transform_func.append(lambda text: text.replace("[oe]", "œ"))
-            files[1].transform_func.append(lambda text: text.replace("[OE]", "Œ"))
-        elif files[1].has_oe_ligature and files[0].has_oe_dp:
-            files[0].transform_func.append(lambda text: text.replace("[oe]", "œ"))
-            files[0].transform_func.append(lambda text: text.replace("[OE]", "Œ"))
-        else:
-            if files[0].has_oe_ligature:
-                files[0].transform_func.append(lambda text: text.replace("œ", "oe"))
-                files[0].transform_func.append(lambda text: text.replace("Œ", "OE"))
-            elif files[1].has_oe_ligature:
-                files[1].transform_func.append(lambda text: text.replace("œ", "oe"))
-                files[1].transform_func.append(lambda text: text.replace("Œ", "OE"))
-
-            if files[0].has_oe_dp:
-                files[0].transform_func.append(lambda text: text.replace("[oe]", "oe"))
-                files[0].transform_func.append(lambda text: text.replace("[OE]", "OE"))
-            elif files[1].has_oe_dp:
-                files[1].transform_func.append(lambda text: text.replace("[oe]", "oe"))
-                files[1].transform_func.append(lambda text: text.replace("[OE]", "OE"))
-
-
-    def do_process(self):
-
-        files = [None, None]
-
-        # Load files
-        for i, fname in enumerate(self.args.filename):
-
-            # Look for file type.
-            if fname.lower().endswith(('.html', '.htm')):
-                files[i] = pgdp_file_html(self.args)
-            else:
-                files[i] = pgdp_file_text(self.args)
-
-            f = files[i]
-
-            f.load(fname)
-            f.process_args(self.args)
-            f.analyze()
-
-
-        # How to process oe ligature
-        self.check_oelig(files)
-
-        # How to process punctuation
-        # Add more as needed
-
-        # Downgrade smart quote to regular quotes if needed
-        if self.args.downgrade_smart_quotes:
-            self.check_char(files, "’", "'") # curly quote to straight
-            self.check_char(files, "‘", "'") # curly quote to straight
-            self.check_char(files, '”', '"')
-            self.check_char(files, '“', '"')
-
-        self.check_char(files, "º", "o") # ordinal o to letter o
-        self.check_char(files, "ª", "a") # ordinal a to letter a
-        self.check_char(files, "–", "-") # ndash to regular dash
-        self.check_char(files, "½", "-1/2")
-        self.check_char(files, "¼", "-1/4")
-        self.check_char(files, "¾", "-3/4")
-        self.check_char(files, '⁄', '/') # fraction
-        self.check_char(files, "′", "'") # prime
-        self.check_char(files, "″", "''") # double prime
-        self.check_char(files, "‴", "'''") # triple prime
-        self.check_char(files, "₁", "1") # subscript 1
-        self.check_char(files, "₂", "2") # subscript 2
-        self.check_char(files, "₃", "3") # subscript 3
-        self.check_char(files, "₄", "4") # subscript 4
-        self.check_char(files, "₅", "5") # subscript 5
-        self.check_char(files, "₆", "6") # subscript 6
-        self.check_char(files, "₇", "7") # subscript 7
-        self.check_char(files, "¹", "1") # superscript 1
-        self.check_char(files, "²", "2") # superscript 2
-        self.check_char(files, "³", "3") # superscript 3
-
-        # Remove non-breakable spaces between numbers. For instance, a
-        # text file could have 250000, and the html could have 250 000.
-        if self.args.suppress_nbsp_num:
-            func = lambda text: re.sub(r"(\d)\u00A0(\d)", r"\1\2", text)
-            files[0].transform_func.append(func)
-            files[1].transform_func.append(func)
-
-        # Suppress shy (soft hyphen)
-        func = lambda text: re.sub(r"\u00AD", r"", text)
-        files[0].transform_func.append(func)
-        files[1].transform_func.append(func)
-
-        # If the original encoding of them is latin1, we must convert a
-        # few UTF8 characters. We assume the default is utf-8. No
-        # provision for any other format.
-        if files[0].myfile.encoding == "iso-8859-1" or files[1].myfile.encoding == "iso-8859-1":
-            for f in files:
-                if f.myfile.encoding != "iso-8859-1":
-                    f.convert_to_latin1 = True
-
-        err_message = ""
-
-        # Apply the various convertions
-        for f in files:
-            err_message += f.convert() or ""
-
-        # Extract footnotes
-        if self.args.extract_footnotes:
-            for f in files:
-                f.extract_footnotes()
-
-        # Transform the final document into a diffable format
-        for f in files:
-            f.transform()
-
-        # Compare the two versions
-        main_diff = self.compare_texts(files[0].text, files[1].text)
-
-        if self.args.extract_footnotes:
-            fnotes_diff = self.compare_texts(files[0].footnotes, files[1].footnotes)
-        else:
-            fnotes_diff = ""
-
-        html_content = self.create_html(files, main_diff, fnotes_diff)
-
-        return err_message, html_content, files[0].myfile.basename, files[1].myfile.basename
-
-
     def simple_html(self):
-        """For debugging purposes. Transform the html and print the
-        text output."""
-
-        fname = self.args.filename[0]
-
-        if fname.lower().endswith(('.html', '.htm')):
-            f = pgdp_file_html(self.args)
-        else:
-            print("Error: not an html file")
-
-        f.load(fname)
-        if f.myfile is None:
-            print("Couldn't load file:", fname)
+        """Debugging only, transform the html and print the text output"""
+        if not self.args.filename[0].lower().endswith(('.html', '.htm')):
+            print('Error: 1st file must be an html file')
             return
+        html_file = PgdpFileHtml(self.args)
+        html_file.load(self.args.filename[0])
+        html_file.cleanup()
+        print(html_file.text)
+        with open('outhtml.txt', 'w', encoding='utf-8') as file:
+            file.write(html_file.text)
 
-        f.process_args(self.args)
-        f.analyze()
+    @staticmethod
+    def check_characters(files):
+        """Check whether each file has the 'best' character. If not, convert.
+        This is used for instance if one version uses curly quotes while the other uses straight.
+        In that case, we need to convert one into the other, to get a smaller diff.
+        """
+        character_checks = {
+            '’': "'",  # close curly single quote to straight
+            '‘': "'",  # open curly single quote to straight
+            '”': '"',  # close curly double quote to straight
+            '“': '"',  # open curly double quote to straight
+            '–': '-',  # en dash to hyphen
+            '—': '--',  # em dash to double hyphen
+            '⁄': '/',  # fraction slash
+            "′": "'",  # prime
+            '″': "''",  # double prime
+            '‴': "'''",  # triple prime
+            '½': '-1/2',
+            '¼': '-1/4',
+            '¾': '-3/4'
+        }
+        for char_best, char_other in character_checks.items():
+            finds_0 = files[0].text.find(char_best)
+            finds_1 = files[1].text.find(char_best)
+            if finds_0 >= 0 and finds_1 >= 0:  # Both have it
+                continue
+            if finds_0 == -1 and finds_1 == -1:  # Neither has it
+                continue
+            # Downgrade one version
+            if finds_0 >= 0:
+                files[0].text = files[0].text.replace(char_best, char_other)
+            else:
+                files[1].text = files[1].text.replace(char_best, char_other)
+        if files[0].footnotes and files[1].footnotes:
+            for char_best, char_other in character_checks.items():
+                finds_0 = files[0].footnotes.find(char_best)
+                finds_1 = files[1].footnotes.find(char_best)
+                if finds_0 >= 0 and finds_1 >= 0:  # Both have it
+                    continue
+                if finds_0 == -1 and finds_1 == -1:  # Neither has it
+                    continue
+                if finds_0 >= 0:
+                    files[0].footnotes = files[0].footnotes.replace(char_best, char_other)
+                else:
+                    files[1].footnotes = files[1].footnotes.replace(char_best, char_other)
 
-        # Remove non-breakable spaces between numbers. For instance, a
-        # text file could have 250000, and the html could have 250 000.
-        if self.args.suppress_nbsp_num:
-            func = lambda text: re.sub(r"(\d)\u00A0(\d)", r"\1\2", text)
-            f.transform_func.append(func)
 
-        # Suppress shy (soft hyphen)
-        func = lambda text: re.sub(r"\u00AD", r"", text)
-        f.transform_func.append(func)
-
-        # Apply the various convertions
-        f.convert()
-
-        # Extract footnotes
-        if self.args.extract_footnotes:
-            f.extract_footnotes()
-
-        # Transform the final document into a diffable format
-        f.transform()
-
-        print(f.text)
-
-
-######################################
-
-# Sample CSS used to display the diffs.
-def diff_css():
-    return """
-body {
-    margin-left: 5%;
-    margin-right: 5%;
-}
-
-del {
-    text-decoration: none;
-    border: 1px solid black;
-    color: #700000 ;
-    background-color: #f4f4f4;
-    font-size: larger;
-}
-ins {
-    text-decoration: none;
-    border: 1px solid black;
-    color: green;
-    background-color: #f4f4f4;
-    font-size: larger;
-}
-.lineno { margin-right: 3em; }
-.sep4 { margin-top: 4em; }
-.bbox { margin-left: auto;
-    margin-right: auto;
-    border: 1px dashed;
-    padding: 0em 1em 0em 1em;
-    background-color: #F0FFFF;
-    width: 90%;
-    max-width: 50em;
-}
-.center { text-align:center; }
-
-/* Use a CSS counter to number each diff. */
-body {
-  counter-reset: diff;  /* set diff counter to 0 */
-}
-hr:before {
-  counter-increment: diff; /* inc the diff counter ... */
-  content: "Diff " counter(diff) ": "; /* ... and display it */
-}
-
-.error-border { border-style:double; border-color:red; border-width:15px; }
-"""
-
-# Describe how to use the diffs
+# noinspection PyPep8
 def html_usage(filename1, filename2):
-    return """
+    """Describe how to use the diffs"""
+    # noinspection PyPep8
+    return f"""
     <div class="bbox">
       <p class="center">— Note —</p>
-      <p>
-        The first number is the line number in the first file (""" + filename1 + """)<br />
-        The second number is the line number in the second file (""" + filename2 + """)<br />
-        Line numbers can sometimes be very approximate.
-      </p>
-      <p>
-        Deleted words that were in the first file but not in the second will appear <del>like this</del>.<br />
-        Inserted words that were in the second file but not in the first will appear <ins>like this</ins>.<br />
-        Some of these can be suppressed using with the various options above.
-      </p>
+      <p>The first number is the line number in the first file (<b>{filename1}</b>)<br />
+        The second number is the line number in the second file (<b>{filename2}</b>)<br />
+        Line numbers can sometimes be very approximate.</p>
+      <p>Deleted words that were in the first file but not in the second will appear <del>like
+         this</del>.<br />
+        Inserted words that were in the second file but not in the first will appear <ins>like
+         this</ins>.</p>
     </div>
     """
 
 
-def output_html(args, html_content, filename1, filename2):
-    # Outputs a complete HTML file
+def output_html(html_content, filename1, filename2, css):
+    """Outputs a complete HTML file"""
     print("""
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <head>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
-    <meta http-equiv="Content-Style-Type" content="text/css" />
-    <title>
-      Compare """ + filename1 + " and " + filename2 + """
-    </title>
-    <style type="text/css">
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Compare""" + filename1 + " and " + filename2 + """</title>
+  <style type="text/css">
 """)
-
-    print(diff_css())
-
+    print(DIFF_CSS)
     print("""
-    </style>
-  </head>
+  </style>
+</head>
 <body>
 """)
-
-    print("<h1>" + filename1 + " and " + filename2 + "</h1>")
+    print(f'<h1>Diff of <span class="first">{filename1}</span> and'
+          f' <span class="second">{filename2}</span></h1>')
     print(html_usage(filename1, filename2))
-    print('<p>Custom CSS added on command line: ' + " ".join(args.css) + '</p>')
-
+    if css:
+        print('<p>Custom CSS added on command line: ' + " ".join(css) + '</p>')
     print(html_content)
     print("""
-  </body>
+</body>
 </html>
 """)
 
+
 def main():
-
-    parser = argparse.ArgumentParser(description='Diff text document for PGDP PP.')
-
+    """Main program"""
+    parser = argparse.ArgumentParser(description='Diff text/HTML documents for PGDP'
+                                                 ' Post-Processors.')
     parser.add_argument('filename', metavar='FILENAME', type=str,
-                        help='input text file', nargs=2)
-    parser.add_argument('--ignore-format', action='store_true', default=False,
-                        help='Silence formating differences')
-    parser.add_argument('--suppress-footnote-tags', action='store_true', default=False,
-                        help='Suppress "[Footnote ?:" marks')
-    parser.add_argument('--suppress-illustration-tags', action='store_true', default=False,
-                        help='Suppress "[Illustration:" marks')
-    parser.add_argument('--suppress-sidenote-tags', action='store_true', default=False,
-                        help='Suppress "[Sidenote:" marks')
+                        help='input files', nargs=2)
     parser.add_argument('--ignore-case', action='store_true', default=False,
                         help='Ignore case when comparing')
     parser.add_argument('--extract-footnotes', action='store_true', default=False,
                         help='Extract and process footnotes separately')
-    parser.add_argument('--ignore-0-space', action='store_true', default=False,
-                        help='HTML: suppress zero width space (U+200b)')
-    parser.add_argument('--suppress-nbsp-num', action='store_true', default=False,
-                        help="Suppress non-breakable spaces between numbers")
-    parser.add_argument('--css-smcap', type=str, default=None,
-                        help="HTML: Transform small caps into uppercase (U), lowercase (L) or title (T)")
-    parser.add_argument('--css-bold', type=str, default=None,
-                        help="HTML: Surround bold strings with this string")
-    parser.add_argument('--css', type=str, default=[], action='append',
-                        help="HTML: Insert transformation CSS")
+    parser.add_argument('--suppress-footnote-tags', action='store_true', default=False,
+                        help='TXT: Suppress "[Footnote #:" marks')
+    parser.add_argument('--suppress-illustration-tags', action='store_true', default=False,
+                        help='TXT: Suppress "[Illustration:" marks')
+    parser.add_argument('--suppress-sidenote-tags', action='store_true', default=False,
+                        help='TXT: Suppress "[Sidenote:" marks')
+    parser.add_argument('--ignore-format', action='store_true', default=False,
+                        help='In Px/Fx versions, silence formatting differences')
     parser.add_argument('--suppress-proofers-notes', action='store_true', default=False,
                         help="In Px/Fx versions, remove [**proofreaders notes]")
     parser.add_argument('--regroup-split-words', action='store_true', default=False,
                         help="In Px/Fx versions, regroup split wo-* *rds")
-    parser.add_argument('--css-greek-title-plus', action='store_true', default=False,
-                        help="HTML: use greek transliteration in title attribute")
+    parser.add_argument('--txt-cleanup-type', type=str, default='b',
+                        help="TXT: In Px/Fx versions, type of text cleaning -- (b)est effort,"
+                             " (n)one, (p)roofers")
     parser.add_argument('--css-add-illustration', action='store_true', default=False,
                         help="HTML: add [Illustration ] tag")
     parser.add_argument('--css-add-sidenote', action='store_true', default=False,
                         help="HTML: add [Sidenote: ...]")
+    parser.add_argument('--css-smcap', type=str, default=None,
+                        help="HTML: Transform small caps into uppercase (U), lowercase (L) or"
+                             " title case (T)")
+    parser.add_argument('--css-bold', type=str, default='=',
+                        help="HTML: Surround bold strings with this string")
+    parser.add_argument('--css', type=str, default=[], action='append',
+                        help="HTML: Insert transformation CSS")
     parser.add_argument('--css-no-default', action='store_true', default=False,
                         help="HTML: do not use default transformation CSS")
-    parser.add_argument('--without-html-header', action='store_true', default=False,
-                        help="HTML: do not output html header and footer")
-    parser.add_argument('--txt-cleanup-type', type=str, default='b',
-                        help="TXT: Type of text cleaning -- (b)est effort, (n)one, (p)roofers")
+    parser.add_argument('--suppress-nbsp-num', action='store_true', default=False,
+                        help="HTML: Suppress non-breakable spaces between numbers")
+    parser.add_argument('--ignore-0-space', action='store_true', default=False,
+                        help='HTML: suppress zero width space (U+200b)')
+    parser.add_argument('--css-greek-title-plus', action='store_true', default=False,
+                        help="HTML: use greek transliteration in title attribute")
     parser.add_argument('--simple-html', action='store_true', default=False,
-                        help="HTML: Process the html file and print the output (debug)")
-
+                        help="HTML: Process just the html file and print the output (debug)")
     args = parser.parse_args()
 
-    x = CompPP(args)
-    if args.simple_html:
-        x.simple_html()
-    else:
-        _, html_content, fn1, fn2 = x.do_process()
+    if args.extract_footnotes and args.suppress_footnote_tags:
+        raise SyntaxError("Cannot use both --extract-footnotes and --suppress-footnote-tags")
 
-        output_html(args, html_content, fn1, fn2)
+    compare = PPComp(args)
+    if args.simple_html:
+        compare.simple_html()
+    else:
+        html_content, file1, file2 = compare.do_process()
+        output_html(html_content, file1, file2, args.css)
+
+
+def dumptree(tree):
+    """Save tree for debug"""
+    with open('tmptree.txt', 'w', encoding='utf-8') as file:
+        for node in tree.iter():
+            if node.text:
+                file.write(node.tag + ': ' + node.text + '\n')
+            else:
+                file.write(node.tag + '\n')
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This is humbly supplied for you to use or not as you see fit.

Copied from DistributedProofreaders/ppcomp project, file /ppcomp/ppcomp.py

I have been comparing it to results from both PPWB and PPTools versions, and don't see any unexpected differences.

Changes:
    use html5parser.
    eliminate oe ligature transforms, treat same as ae.
    --css-bold option has default of '=',
    changed boilerplate removal to latest format
    added super/subscript conversions (`<sup>1</sup>` or ^1 to '¹'.

I did a LOT of rewriting, mainly to make each functionality accessible for unit testing, partly code "cleanup" or just adapting to my style so I could understand it better.

--extract-footnotes needs work, but it shouldn't be any worse.